### PR TITLE
Create Mentoring Career List View And Mento Update, Delete

### DIFF
--- a/src/action/action_menti.js
+++ b/src/action/action_menti.js
@@ -17,6 +17,11 @@ export const STUDENT_RELEASE_CURRENT_MENTI_SUCCESS = 'STUDENT_RELEASE_CURRENT_ME
 export const STUDENT_RELEASE_CURRENT_MENTI_FAILURE = 'STUDENT_RELEASE_CURRENT_MENTI_FAILURE';
 export const RESET_STUDENT_RELEASE_CURRENT_MENTI = 'RESET_STUDENT_RELEASE_CURRENT_MENTI';
 
+export const STUDENT_LOAD_MENTI_CAREERS = 'STUDENT_LOAD_MENTI_CAREERS';
+export const STUDENT_LOAD_MENTI_CAREERS_SUCCESS = 'STUDENT_LOAD_MENTI_CAREERS_SUCCESS';
+export const STUDENT_LOAD_MENTI_CAREERS_FAILURE = 'STUDENT_LOAD_MENTI_CAREERS_FAILURE';
+export const RESET_STUDENT_LOAD_MENTI_CAREERS = 'RESET_STUDENT_LOAD_MENTI_CAREERS';
+
 export function studentLoadTeamList(identity){
     const request = axios({
         url : `${ROOT_URL}/menti/infos/${identity}`,
@@ -109,5 +114,37 @@ export function studentReleaseCurrentMentiFailure(error){
 export function resetStudentReleaseCurrentMenti(){
     return {
         type : RESET_STUDENT_RELEASE_CURRENT_MENTI
+    }
+}
+
+export function studentLoadMentiCareers(identity){
+    const request = axios({
+        url : `${ROOT_URL}/mentis/career/${identity}`,
+        method : 'get'
+    });
+    return {
+        type : STUDENT_LOAD_MENTI_CAREERS,
+        payload : request
+    }
+}
+
+
+export function studentLoadMentiCareersSuccess(careers){
+    return {
+        type : STUDENT_LOAD_MENTI_CAREERS_SUCCESS,
+        payload : careers.data
+    }
+}
+
+export function studentLoadMentiCareersFailure(error){
+    return {
+        type : STUDENT_LOAD_MENTI_CAREERS_FAILURE,
+        payload : error
+    }
+}
+
+export function resetStudentLoadMentiCareers(){
+    return {
+        type : RESET_STUDENT_LOAD_MENTI_CAREERS
     }
 }

--- a/src/action/action_mento.js
+++ b/src/action/action_mento.js
@@ -12,6 +12,21 @@ export const STUDENT_APPLY_MENTO_SUCCESS = 'STUDENT_APPLY_MENTO_SUCCESS';
 export const STUDENT_APPLY_MENTO_FAILURE = 'STUDENT_APPLY_MENTO_FAILURE';
 export const RESET_STUDENT_APPLY_MENTO = 'RESET_STUDENT_APPLY_MENTO';
 
+export const STUDENT_LOAD_MENTO_CAREERS = 'STUDENT_LOAD_MENTO_CAREERS';
+export const STUDENT_LOAD_MENTO_CAREERS_SUCCESS = 'STUDENT_LOAD_MENTO_CAREERS_SUCCESS';
+export const STUDENT_LOAD_MENTO_CAREERS_FAILURE = 'STUDENT_LOAD_MENTO_CAREERS_FAILURE';
+export const RESET_STUDENT_LOAD_MENTO_CAREERS = 'RESET_STUDENT_LOAD_MENTO_CAREERS';
+
+export const STUDENT_UPDATE_MENTO_INFO = 'STUDENT_UPDATE_MENTO_INFO';
+export const STUDENT_UPDATE_MENTO_INFO_SUCCESS = 'STUDENT_UPDATE_MENTO_INFO_SUCCESS';
+export const STUDENT_UPDATE_MENTO_INFO_FAILURE = 'STUDENT_UPDATE_MENTO_INFO_FAILURE';
+export const RESET_STUDENT_UPDATE_MENTO_INFO = 'RESET_STUDENT_UPDATE_MENTO_INFO';
+
+export const STUDENT_DELETE_MENTO_INFO = 'STUDENT_DELETE_MENTO_INFO';
+export const STUDENT_DELETE_MENTO_INFO_SUCCESS = 'STUDENT_DELETE_MENTO_INFO_SUCCESS';
+export const STUDENT_DELETE_MENTO_INFO_FAILURE = 'STUDENT_DELETE_MENTO_INFO_FAILURE';
+export const RESET_STUDENT_DELETE_MENTO_INFO = 'RESET_STUDENT_DELETE_MENTO_INFO';
+
 export function studentLoadApplyModel(identity){
     const request = axios({
         url : `${ROOT_URL}/team/model/${identity}`,
@@ -78,5 +93,116 @@ export function studentApplyMentoFailure(error){
 export function resetStudentApplyMento(){
     return {
         type : RESET_STUDENT_APPLY_MENTO
+    }
+}
+
+export function studentLoadMentoCareers(identity){
+    const request = axios({
+        url : `${ROOT_URL}/teams/career/${identity}`,
+        method : 'get'
+    });
+    return {
+        type : STUDENT_LOAD_MENTO_CAREERS,
+        payload : request
+    }
+}
+
+export function studentLoadMentoCareersSuccess(careers){
+    return {
+        type : STUDENT_LOAD_MENTO_CAREERS_SUCCESS,
+        payload : careers.data
+    }
+}
+
+export function studentLoadMentoCareersFailure(error){
+    return {
+        type : STUDENT_LOAD_MENTO_CAREERS_FAILURE,
+        payload : error
+    }
+}
+
+export function resetStudentLoadMentoCareers(){
+    return {
+        type : RESET_STUDENT_LOAD_MENTO_CAREERS
+    }
+}
+
+export function studentUpdateMentoInfo(identity, mentoForm, advFile){
+    let formData = new FormData();
+    if(advFile !== null) {
+        formData.append('applicationModel', new Blob([JSON.stringify(mentoForm)], {type: 'application/json'}));
+        formData.append('advFile', advFile);
+    }
+
+    const request = advFile !== null ?
+        axios({
+            url : `${ROOT_URL}/team/${identity}`,
+            method : 'put',
+            data : formData,
+            headers : {
+                "Content-Type" : "multipart/form-data"
+            }
+        }) : axios({
+            url : `${ROOT_URL}/team/info/${identity}`,
+            method : 'put',
+            data : mentoForm
+        });
+    return {
+        type : STUDENT_UPDATE_MENTO_INFO,
+        payload : request
+    }
+}
+
+export function studentUpdateMentoInfoSuccess(message){
+    return {
+        type : STUDENT_UPDATE_MENTO_INFO_SUCCESS,
+        payload : message.data
+    }
+}
+
+export function studentUpdateMentoInfoFailure(error){
+    return {
+        type : STUDENT_UPDATE_MENTO_INFO_FAILURE,
+        payload : error
+    }
+}
+
+export function resetStudentUpdateMentoInfo(){
+    return {
+        type : RESET_STUDENT_UPDATE_MENTO_INFO
+    }
+}
+
+export function studentDeleteMentoInfo(identity){
+    const request = axios({
+        url: `${ROOT_URL}/team/cancellation/${identity}`,
+        method: 'delete',
+        headers: {
+            "Content-Type": "multipart/form-data"
+        }
+    });
+    return {
+        type : STUDENT_DELETE_MENTO_INFO,
+        payload : request
+    }
+}
+
+export function studentDeleteMentoInfoSuccess(message){
+    return {
+        type : STUDENT_DELETE_MENTO_INFO_SUCCESS,
+        payload : message.data
+    }
+}
+
+export function studentDeleteMentoInfoFailure(error){
+    return {
+        type : STUDENT_LOAD_MENTO_CAREERS_FAILURE,
+        payload : error
+    }
+}
+
+export function resetStudentDeleteMentoInfo(){
+    return {
+        type : RESET_STUDENT_DELETE_MENTO_INFO
     }
 }

--- a/src/component/left_menu/MenuData.js
+++ b/src/component/left_menu/MenuData.js
@@ -76,6 +76,14 @@ export const introDefaultItems = (
                 <ListItemText primary="일정 확인" />
             </ListItem>
         </Link>
+        <Link to="/application/mento_list" style={{ textDecoration: 'none' }}>
+            <ListItem button>
+                <ListItemIcon>
+                    <ArrowForwardIcon />
+                </ListItemIcon>
+                <ListItemText primary="멘토링 목록" />
+            </ListItem>
+        </Link>
     </div>
 );
 
@@ -101,6 +109,14 @@ export const introAdminItems = (
                     <ArrowForwardIcon />
                 </ListItemIcon>
                 <ListItemText primary="일정 확인" />
+            </ListItem>
+        </Link>
+        <Link to="/application/mento_list" style={{ textDecoration: 'none' }}>
+            <ListItem button>
+                <ListItemIcon>
+                    <ArrowForwardIcon />
+                </ListItemIcon>
+                <ListItemText primary="멘토링 목록" />
             </ListItem>
         </Link>
         <Link to="/intro/edit" style={{ textDecoration: 'none' }}>
@@ -144,22 +160,6 @@ export const applicationItems = (
                     <ArrowForwardIcon />
                 </ListItemIcon>
                 <ListItemText primary="멘티 신청" />
-            </ListItem>
-        </Link>
-        <Link to="/application/mento_list" style={{ textDecoration: 'none' }}>
-            <ListItem button>
-                <ListItemIcon>
-                    <ArrowForwardIcon />
-                </ListItemIcon>
-                <ListItemText primary="멘토링 목록" />
-            </ListItem>
-        </Link>
-        <Link to="/application/confirm" style={{ textDecoration: 'none' }}>
-            <ListItem button>
-                <ListItemIcon>
-                    <ArrowForwardIcon />
-                </ListItemIcon>
-                <ListItemText primary="신청 내역 확인" />
             </ListItem>
         </Link>
     </div>

--- a/src/component/mentoring_confirm_page/MentoringCareerView.js
+++ b/src/component/mentoring_confirm_page/MentoringCareerView.js
@@ -1,0 +1,364 @@
+import React, {Component} from 'react';
+import axios from 'axios';
+import { withRouter } from 'react-router-dom';
+import {reduxForm, Field, SubmissionError} from 'redux-form';
+import Select from 'react-select';
+
+import PropTypes from 'prop-types';
+
+import { withStyles } from '@material-ui/core/styles';
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+
+import RemoveIcon from '@material-ui/icons/Remove';
+import FolderIcon from '@material-ui/icons/FolderShared';
+import CheckIcon from '@material-ui/icons/Check';
+import ChildIcon from '@material-ui/icons/ChildCare';
+import FaceIcon from '@material-ui/icons/Face';
+import EditIcon from '@material-ui/icons/Edit';
+
+import {
+    renderTextField, renderMultiTextField, renderDropzoneInput
+} from "../form_render";
+
+import {
+    studentUpdateMentoInfo, studentUpdateMentoInfoSuccess, studentUpdateMentoInfoFailure
+} from "../../action/action_mento";
+
+const RESOURCE_URL = 'http://127.0.0.1:8082/MentoAPI';
+
+const styles = theme => ({
+    form: {
+        width: '100%',
+        marginTop: theme.spacing.unit,
+    },
+    textField: {
+        marginLeft: theme.spacing.unit,
+        marginRight: theme.spacing.unit,
+        width: (window.innerWidth >= 450) ? 420 : 300,
+    },
+    avatar: {
+        margin: theme.spacing.unit,
+        backgroundColor: theme.palette.secondary.main,
+    },
+    leftIcon: {
+        marginRight: theme.spacing.unit,
+    }
+});
+
+function validate(values){
+    var errors = {};
+    var hasErrors = false;
+    if(!values.teamName || values.teamName.trim() === ''){
+        errors.teamName = '멘토링 팀 이름을 입력하세요.';
+        hasErrors = true;
+    }
+
+    if(!values.person){
+        errors.person = '멘토링 팀 인원을 입력하세요.';
+        hasErrors = true;
+    } else if(isNaN(values.person)){
+        errors.person = '멘토링 인원은 숫자로만 입력하세요.';
+        hasErrors = true;
+    } else if(values.person * 1 < 3 || values.person * 1 > 10) {
+        errors.person = '멘토링 인원은 3명 부터 10명까지만 입력하세요.';
+        hasErrors = true;
+    }
+
+    if(!values.teamName || values.teamName.trim() === ''){
+        errors.teamName = '멘토링 팀 이름을 입력하세요.';
+        hasErrors = true;
+    }
+
+    if(!values.qualify || values.qualify.trim() === ''){
+        errors.qualify = '자격 증명을 입력하세요.';
+        hasErrors = true;
+    }
+
+    if(!values.advertise || values.advertise.trim() === ''){
+        errors.advertise = '멘토링 홍보 / 안내 글을 입력하세요.';
+        hasErrors = true;
+    }
+
+    if(values.advFile && values.advFile.length >= 1){
+        const file = values.advFile[0];
+        if(file.size > 2097152) {
+            errors.advFile = '파일은 2MB 이하로 첨부하시길 바랍니다.';
+            hasErrors = true;
+        }
+    }
+
+    return hasErrors && errors;
+}
+
+const validateAndApplicateMento = (values, dispatch) => {
+    const fileArray = values.advFile;
+    let applyModel = {
+        mento : values && values.mento,
+        teamName : values && values.teamName,
+        person : values && values.person * 1,
+        advertise : values && values.advertise,
+        qualify : values && values.qualify,
+        subjects : values && values.subjects.map(subject => subject.value)
+    }
+    dispatch(studentUpdateMentoInfo(values.mento, applyModel, fileArray !== undefined ? fileArray[0] : null)).then((response) => {
+        if (response.payload && response.payload.status !== 200) {
+            dispatch(studentUpdateMentoInfoFailure(response.payload));
+            throw new SubmissionError(response.payload.data);
+        }
+        dispatch(studentUpdateMentoInfoSuccess(response.payload));
+    });
+}
+
+
+class MentoringCareerView extends Component{
+    constructor(props){
+        super(props);
+        this.state = { semester : null, subjects : [], selectSubs : [] };
+    }
+
+    componentWillMount(){
+        axios.get(`${RESOURCE_URL}/semester/current`).then(response => this.setState({ semester : response.data }));
+        axios.get(`${RESOURCE_URL}/subjects`).then(response => this.setState({ subjects : response.data }));
+    }
+
+    componentDidMount(){
+        const { principal } = this.props.accessAccount;
+        this.props.fetchMentoCareers(principal.identity);
+        this.props.fetchMentiCareers(principal.identity);
+        this.props.fetchMentoApply(principal.identity);
+    }
+
+    componentWillUnmount(){
+        this.props.resetFetchMentoCareers();
+        this.props.resetFetchMentiCareers();
+        this.props.resetFetchMentoApply();
+        this.props.resetExecuteSaveInfo();
+        this.props.resetExecuteDeleteInfo();
+    }
+
+    handleChange(event) {
+        this.setState({ selectSubs : event });
+    }
+
+    handleClickMentoCancel(){
+        const { principal } = this.props.accessAccount;
+        const hasCancel = window.confirm("이번 학기의 멘토 신청 자체를 삭제합니다. 삭제를 해도 멘토 신청은 다시 가능합니다. 계속 하시겠습니까?");
+        if(hasCancel)
+            this.props.executeDeleteMentoInfo(principal.identity);
+    }
+
+    render() {
+        const { principal } = this.props.accessAccount;
+        const { semester, subjects, selectSubs } = this.state;
+        const { classes, handleSubmit, mentoCareerList, mentiCareerList, saveStatus, deleteStatus } = this.props;
+        const { model } = this.props.applyModel;
+
+        if(model !== null && model !== ''){
+            this.props.change('mento', principal.identity);
+            this.props.change('subjects', selectSubs);
+        }
+
+        let mentoCareers = mentoCareerList.careers.length > 0 ?
+            mentoCareerList.careers.map((career, idx) =>
+                <tr key={`mento_${idx}`}>
+                    <td>{career.semester && career.semester.name}</td>
+                    <td>{career.name}</td>
+                    <td>{career.appPerson} / {career.limPerson}</td>
+                    <td>{career.subjects.map(subject => <span className="w3-tag w3-round-large w3-orange">{subject.name}</span>)}</td>
+                    <td className={career.status === 'LOADING' ? '' : career.status === 'PERMIT' ? 'w3-pale-green' : 'w3-pale-red'}>{career.status === 'LOADING' ? '확인 중' : career.status === 'PERMIT' ? '허가' : '반려'}</td>
+                </tr>
+            ) :
+            <tr>
+                <td colSpan="5">멘토를 신청한 내역이 없습니다.</td>
+            </tr>
+
+        let mentiCareers = mentiCareerList.careers.length > 0 ?
+            mentiCareerList.careers.map((career, idx) =>
+                <tr key={`mento_${idx}`}>
+                    <td>{career.semester && career.semester.name}</td>
+                    <td>{career.name}</td>
+                    <td>{career.appPerson} / {career.limPerson}</td>
+                    <td>{career.subjects.map(subject => <span className="w3-tag w3-round-large w3-orange">{subject.name}</span>)}</td>
+                    <td className={career.status === 'LOADING' ? '' : career.status === 'PERMIT' ? 'w3-pale-green' : 'w3-pale-red'}>{career.status === 'LOADING' ? '확인 중' : career.status === 'PERMIT' ? '허가' : '반려'}</td>
+                </tr>
+            ) :
+            <tr>
+                <td colSpan="5">멘티를 신청한 내역이 없습니다.</td>
+            </tr>
+
+        const mentoForm =
+            (model !== null && model !== '') ?
+                <form className={classes.form} onSubmit={handleSubmit(validateAndApplicateMento)}>
+                    <Grid align="center">
+                        <div>
+                            <Avatar className={classes.avatar}>
+                                <EditIcon />
+                            </Avatar>
+                        </div>
+
+                        <div>
+                            <h3>{semester && semester.name} 멘토 신청 내역 수정</h3>
+                            <p>이번 학기 멘토 신청 내역입니다.</p>
+                            <p>멘토링 내역을 수정할 때 주제를 다시 입력해주셔야 합니다.</p>
+                            <p>파일 같은 경우는 내용을 수정할 경우에만 업로드하시길 바랍니다.</p>
+                        </div>
+                        <br/>
+                        <div>
+                            <Field name="teamName" className={classes.textField} type="text"
+                                   component={renderTextField} label="팀 이름" placeholder="여러분들의 재치 있는 멘토링 팀 이름을 입력하세요." />
+                        </div>
+                        <br/>
+
+                        <div>
+                            <Field name="person" className={classes.textField} type="text"
+                                   component={renderTextField} label="멘토링 인원수" placeholder="멘토링을 운영하기 원하는 인원 수를 입력하세요." />
+                        </div>
+                        <br/>
+
+                        <div>
+                            <Field name="qualify" className={classes.textField} type="text"
+                                   component={renderTextField} label="멘토 자격 증명" placeholder="자격 증명을 위한 과목 학점 혹은 실력 증명 이력을 입력하세요." />
+                        </div>
+                        <br/>
+
+                        <div>
+                            <Field name="advertise" className={classes.textField} type="text"
+                                   component={renderMultiTextField} label="멘토링 홍보 및 안내" placeholder="멘토링 홍보를 위한 글 혹은 안내문을 입력하세요.(개행 가능)" />
+                        </div>
+                        <br/>
+
+                        <div style={{ width : '340px'}}>
+                            <label>멘토링 주제 선택</label>
+                            <Select
+                                value={selectSubs}
+                                onChange={this.handleChange.bind(this)}
+                                options={subjects.map(subject => ({ value : subject.id, label : subject.name }))}
+                                isMulti
+                            />
+                        </div>
+                        <br/>
+
+                        <div>
+                            <label>멘토링 홍보 / 안내 파일</label>
+                            <p>이미지 파일(jpg, jpeg, png), PDF 파일, Word(doc, docx), 한글(hwp) 파일 등 하나의 파일만 올릴 수 있습니다.</p>
+                            <Field
+                                name="advFile"
+                                component={renderDropzoneInput}
+                                accept={"image/jpeg, image/png, image/jpg, application/pdf, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, .hwp"}
+                                multiple={false}
+                            />
+                            <br/>
+                        </div>
+                        <br/>
+
+                        <div>
+                            {
+                                selectSubs.length > 0 ?
+                                    <Button variant="contained" type="submit" color="primary">
+                                        <CheckIcon className={classes.leftIcon}/> 수정하기
+                                    </Button> : <p>멘토링 주제를 선택하셔야 수정이 가능합니다.</p>
+                            }
+
+                            &nbsp;
+                            <button type="button" className="w3-button w3-red w3-round-large" onClick={() => this.handleClickMentoCancel()}>
+                                <RemoveIcon className={classes.leftIcon}/> 멘토 취소하기
+                            </button>
+                        </div>
+                        <br/>
+                    </Grid>
+                </form>
+            : null;
+
+        if(saveStatus.message){
+            alert(saveStatus.message);
+            this.props.history.push("/application/confirm/_refresh");
+        } else if(saveStatus.error) {
+            alert("멘토 정보 수정 중 오류가 발생했습니다. 홈 으로 이동 합니다.");
+            this.props.history.push("/");
+        }
+
+        if(deleteStatus.message){
+            alert(deleteStatus.message);
+            this.props.history.push("/application/confirm/_refresh");
+        } else if(deleteStatus.error) {
+            alert("멘토 정보 삭제 중 오류가 발생했습니다. 홈 으로 이동 합니다.");
+            this.props.history.push("/");
+        }
+
+
+        return (
+            <div>
+                <Grid align="center">
+                    <hr/>
+                    <div>
+                        <Avatar className={classes.avatar}>
+                            <FolderIcon/>
+                        </Avatar>
+                    </div>
+
+                    <div>
+                        <h3>SM 사업 신청 내역</h3>
+                        <p>SM Mentoring 사업 신청 경력입니다.</p>
+                        <p>신청 경력은 멘토와 멘티 나뉘어서 나옵니다.</p>
+                    </div>
+                    <br/>
+
+                    <h2><FaceIcon /> 멘토 신청 결과 조회</h2>
+                    <br/>
+                    <div className={`w3-responsive ${ window.innerWidth <= 425 ? 'w3-small' : 'w3-large'}`} style={{ width : window.innerWidth <= 425 ? '95%' : '60%'}}>
+                        <table className="w3-table-all w3-centered">
+                            <thead>
+                            <tr className="w3-khaki">
+                                <th>학기</th>
+                                <th>팀 이름</th>
+                                <th>제적 인원</th>
+                                <th>주제</th>
+                                <th>신청 결과</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {mentoCareers}
+                            </tbody>
+                        </table>
+                    </div>
+                    <br/>
+
+                    <h2><ChildIcon /> 멘티 신청 결과 조회</h2>
+                    <br/>
+                    <div className={`w3-responsive ${ window.innerWidth <= 425 ? 'w3-small' : 'w3-large'}`} style={{ width : window.innerWidth <= 425 ? '95%' : '60%'}}>
+                        <table className="w3-table-all w3-centered">
+                            <thead>
+                            <tr className="w3-khaki">
+                                <th>학기</th>
+                                <th>팀 이름</th>
+                                <th>제적 인원</th>
+                                <th>주제</th>
+                                <th>신청 결과</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {mentiCareers}
+                            </tbody>
+                        </table>
+                    </div>
+                    <br/>
+
+                </Grid>
+                <br/>
+                {mentoForm}
+            </div>
+        )
+    }
+}
+
+MentoringCareerView.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default reduxForm({
+    form : 'mentoUpdateForm',
+    enableReinitialize : true,
+    validate
+})((withStyles(styles))(withRouter(MentoringCareerView)));

--- a/src/component/mentoring_confirm_page/index.js
+++ b/src/component/mentoring_confirm_page/index.js
@@ -1,0 +1,1 @@
+export {default as MentoringCareerView} from './MentoringCareerView';

--- a/src/container/MentoringCareerViewContainer.js
+++ b/src/container/MentoringCareerViewContainer.js
@@ -1,0 +1,69 @@
+import { MentoringCareerView } from "../component/mentoring_confirm_page";
+import { connect } from 'react-redux';
+import {
+    studentLoadMentoCareers, studentLoadMentoCareersSuccess, studentLoadMentoCareersFailure,
+    resetStudentLoadMentoCareers,
+    studentLoadApplyModel, studentLoadApplyModelSuccess, studentLoadApplyModelFailure, resetStudentLoadApplyModel,
+    resetStudentUpdateMentoInfo, studentDeleteMentoInfo, studentDeleteMentoInfoSuccess, studentDeleteMentoInfoFailure, resetStudentDeleteMentoInfo
+} from "../action/action_mento";
+import {
+    studentLoadMentiCareers, studentLoadMentiCareersSuccess, studentLoadMentiCareersFailure, resetStudentLoadMentiCareers
+} from "../action/action_menti";
+
+function mapStateToProps(state){
+    const { model } = state.mento.applyModel;
+    const initialData = {
+        teamName : model && model.teamName,
+        person : model && model.person,
+        advertise : model && model.advertise,
+        qualify : model && model.qualify
+    }
+    return {
+        initialValues : initialData,
+        mentoCareerList : state.mento.careerList,
+        mentiCareerList : state.menti.careerList,
+        applyModel : state.mento.applyModel,
+        accessAccount : state.account.accessAccount,
+        saveStatus : state.mento.saveStatus,
+        deleteStatus : state.mento.deleteStatus
+    }
+}
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        fetchMentoCareers : (identity) => dispatch(studentLoadMentoCareers(identity)).then((response) => {
+            if(!response.error)
+                dispatch(studentLoadMentoCareersSuccess(response.payload));
+            else
+                dispatch(studentLoadMentoCareersFailure(response.payload));
+        }),
+        resetFetchMentoCareers : () => dispatch(resetStudentLoadMentoCareers()),
+        fetchMentiCareers : (identity) => dispatch(studentLoadMentiCareers(identity)).then((response) => {
+            if(!response.error)
+                dispatch(studentLoadMentiCareersSuccess(response.payload));
+            else
+                dispatch(studentLoadMentiCareersFailure(response.payload));
+        }),
+        resetFetchMentiCareers : () => dispatch(resetStudentLoadMentiCareers()),
+        fetchMentoApply : (identity) => {
+            dispatch(studentLoadApplyModel(identity)).then(response => {
+                if(!response.error){
+                    dispatch(studentLoadApplyModelSuccess(response.payload));
+                } else {
+                    dispatch(studentLoadApplyModelFailure(response.payload));
+                }
+            })
+        },
+        executeDeleteMentoInfo : (identity) => dispatch(studentDeleteMentoInfo(identity)).then(response => {
+            if(!response.error)
+                dispatch(studentDeleteMentoInfoSuccess(response.payload));
+            else
+                dispatch(studentDeleteMentoInfoFailure(response.payload));
+        }),
+        resetFetchMentoApply : () => dispatch(resetStudentLoadApplyModel()),
+        resetExecuteSaveInfo : () => dispatch(resetStudentUpdateMentoInfo()),
+        resetExecuteDeleteInfo : () => dispatch(resetStudentDeleteMentoInfo())
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MentoringCareerView);

--- a/src/page/mentoring_career_view_page/MentoringCareerViewPage.js
+++ b/src/page/mentoring_career_view_page/MentoringCareerViewPage.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ChalkImage from '../../resource_image/chalk_photo.png';
+import MentoringCareerViewContainer from '../../container/MentoringCareerViewContainer';
+
+const MentoringCareerViewPage = () => (
+    <div>
+        <div>
+            <img src={ChalkImage} width="100%" className="w3-round-large" />
+            <br/><br/>
+            <MentoringCareerViewContainer />
+        </div>
+    </div>
+);
+
+export default MentoringCareerViewPage;

--- a/src/reducer/reducer_menti.js
+++ b/src/reducer/reducer_menti.js
@@ -1,7 +1,9 @@
 import {
     STUDENT_LOAD_TEAM_LIST, STUDENT_LOAD_TEAM_LIST_SUCCESS, STUDENT_LOAD_TEAM_LIST_FAILURE, RESET_STUDENT_LOAD_TEAM_LIST,
     STUDENT_APPLY_MENTI, STUDENT_APPLY_MENTI_SUCCESS, STUDENT_APPLY_MENTI_FAILURE, RESET_STUDENT_APPLY_MENTI,
-    STUDENT_RELEASE_CURRENT_MENTI, STUDENT_RELEASE_CURRENT_MENTI_SUCCESS, STUDENT_RELEASE_CURRENT_MENTI_FAILURE, RESET_STUDENT_RELEASE_CURRENT_MENTI
+    STUDENT_RELEASE_CURRENT_MENTI, STUDENT_RELEASE_CURRENT_MENTI_SUCCESS, STUDENT_RELEASE_CURRENT_MENTI_FAILURE, RESET_STUDENT_RELEASE_CURRENT_MENTI,
+    RESET_STUDENT_LOAD_MENTI_CAREERS, STUDENT_LOAD_MENTI_CAREERS, STUDENT_LOAD_MENTI_CAREERS_FAILURE,
+    STUDENT_LOAD_MENTI_CAREERS_SUCCESS
 } from "../action/action_menti";
 
 const INITIAL_STATE = {
@@ -13,6 +15,9 @@ const INITIAL_STATE = {
     },
     deleteStatus : {
         message : null, loading : false, error : null
+    },
+    careerList : {
+        careers : [], loading : false, error : null
     }
 }
 
@@ -48,6 +53,16 @@ export default function(state = INITIAL_STATE, action) {
             return { ...state, deleteStatus : { message : null, loading : false, error : error }};
         case RESET_STUDENT_RELEASE_CURRENT_MENTI :
             return { ...state, deleteStatus : { message : null, loading : false, error : null }};
+
+        case STUDENT_LOAD_MENTI_CAREERS :
+            return { ...state, careerList : { careers : [], loading : true, error : null }};
+        case STUDENT_LOAD_MENTI_CAREERS_SUCCESS :
+            return { ...state, careerList : { careers : action.payload, loading : false, error : null }};
+        case STUDENT_LOAD_MENTI_CAREERS_FAILURE :
+            error = action.payload.data || { message : action.payload.data };
+            return { ...state, careerList : { careers : [], loading : false, error : error }};
+        case RESET_STUDENT_LOAD_MENTI_CAREERS :
+            return { ...state, careerList : { careers : [], loading : false, error : null }};
 
         default :
             return state;

--- a/src/reducer/reducer_mento.js
+++ b/src/reducer/reducer_mento.js
@@ -1,6 +1,9 @@
 import {
     STUDENT_LOAD_APPLY_MODEL, STUDENT_LOAD_APPLY_MODEL_SUCCESS, STUDENT_LOAD_APPLY_MODEL_FAILURE, RESET_STUDENT_LOAD_APPLY_MODEL,
-    STUDENT_APPLY_MENTO, STUDENT_APPLY_MENTO_SUCCESS, STUDENT_APPLY_MENTO_FAILURE, RESET_STUDENT_APPLY_MENTO
+    STUDENT_APPLY_MENTO, STUDENT_APPLY_MENTO_SUCCESS, STUDENT_APPLY_MENTO_FAILURE, RESET_STUDENT_APPLY_MENTO,
+    STUDENT_LOAD_MENTO_CAREERS, STUDENT_LOAD_MENTO_CAREERS_SUCCESS, STUDENT_LOAD_MENTO_CAREERS_FAILURE, RESET_STUDENT_LOAD_MENTO_CAREERS,
+    STUDENT_UPDATE_MENTO_INFO, STUDENT_UPDATE_MENTO_INFO_SUCCESS, STUDENT_UPDATE_MENTO_INFO_FAILURE, RESET_STUDENT_UPDATE_MENTO_INFO,
+    STUDENT_DELETE_MENTO_INFO, STUDENT_DELETE_MENTO_INFO_SUCCESS, STUDENT_DELETE_MENTO_INFO_FAILURE, RESET_STUDENT_DELETE_MENTO_INFO
 } from "../action/action_mento";
 
 const INITIAL_STATE = {
@@ -9,7 +12,16 @@ const INITIAL_STATE = {
     },
     saveStatus : {
         message : null, loading : false, error : null
-    }
+    },
+    careerList : {
+        careers : [], loading : false, error : null
+    },
+    saveStatus : {
+        message : null, loading : false, error : null
+    },
+    deleteStatus : {
+        message : null, loading : false, error : null
+    },
 }
 
 export default function(state = INITIAL_STATE, action) {
@@ -26,14 +38,39 @@ export default function(state = INITIAL_STATE, action) {
             return { ...state, applyModel : { model : null, loading : false, error : null }};
 
         case STUDENT_APPLY_MENTO :
+        case STUDENT_UPDATE_MENTO_INFO :
             return { ...state, saveStatus : { message : null, loading : true, error : null }};
         case STUDENT_APPLY_MENTO_SUCCESS :
+        case STUDENT_UPDATE_MENTO_INFO_SUCCESS :
             return { ...state, saveStatus : { message : action.payload, loading : false, error : null }};
         case STUDENT_APPLY_MENTO_FAILURE :
+        case STUDENT_UPDATE_MENTO_INFO_FAILURE :
             error = action.payload.data || { message : action.payload.data };
             return { ...state, saveStatus : { message : null, loading : false, error : error }};
         case RESET_STUDENT_APPLY_MENTO :
+        case RESET_STUDENT_UPDATE_MENTO_INFO :
             return { ...state, saveStatus : { message : null, loading : false, error : null }};
+
+        case STUDENT_LOAD_MENTO_CAREERS :
+            return { ...state, careerList : { careers : [], loading : true, error : null }};
+        case STUDENT_LOAD_MENTO_CAREERS_SUCCESS :
+            return { ...state, careerList : { careers : action.payload, loading : false, error : null }};
+        case STUDENT_LOAD_MENTO_CAREERS_FAILURE :
+            error = action.payload.data || { message : action.payload.data };
+            return { ...state, careerList : { careers : [], loading : false, error : error }};
+        case RESET_STUDENT_LOAD_MENTO_CAREERS :
+            return { ...state, careerList : { careers : [], loading : false, error : null }};
+
+        case STUDENT_DELETE_MENTO_INFO :
+            return { ...state, deleteStatus : { message : null, loading : true, error : null }};
+        case STUDENT_DELETE_MENTO_INFO_SUCCESS :
+            return { ...state, deleteStatus : { message : action.payload, loading : false, error : null }};
+        case STUDENT_DELETE_MENTO_INFO_FAILURE :
+            error = action.payload.data || { message: action.payload.data };
+            return { ...state, deleteStatus : { message : null, loading : false, error : error }};
+        case RESET_STUDENT_DELETE_MENTO_INFO :
+            return { ...state, deleteStatus : { message : null, loading : false, error : null }};
+
         default :
             return state;
     }

--- a/src/router/AdminRouter.js
+++ b/src/router/AdminRouter.js
@@ -19,6 +19,7 @@ import {MentoApplicationPage} from "../page/mento_application_page";
 import {MentoringPage} from "../page/mentoring_page";
 import {NoticeEditPage} from "../page/notice_edit_page";
 import {MentiApplicationPage} from "../page/menti_application_page";
+import MentoringCareerViewPage from "../page/mentoring_career_view_page/MentoringCareerViewPage";
 
 const AdminRouter = (props) => (
     <div>
@@ -51,6 +52,12 @@ const AdminRouter = (props) => (
             }
             {
                 (props.isStudent) ? <Route exact path="/application/menti/_refresh" render={() => <Redirect to="/application/menti" />} /> : null
+            }
+            {
+                (props.isStudent) ? <Route exact path="/application/confirm" component={MentoringCareerViewPage} /> : null
+            }
+            {
+                (props.isStudent) ? <Route exact path="/application/confirm/_refresh" render={() => <Redirect to="/application/confirm" />} /> : null
             }
             <Route exact path="/account/sign/edit" component={SignUpdatePage} />
             <Route exact path="/account/timetable/edit" component={TimetableEditPage} />

--- a/src/router/ApplicationRouter.js
+++ b/src/router/ApplicationRouter.js
@@ -322,6 +322,12 @@ class ApplicationRouter extends Component{
                                             <Link to="/account/profile/edit" style={{ textDecoration: 'none' }}>
                                                 <MenuItem onClick={this.handleClose}>프로필 설정</MenuItem>
                                             </Link>
+                                            {
+                                                principal.type === 'STUDENT' ?
+                                                    <Link to="/application/confirm" style={{ textDecoration: 'none' }}>
+                                                        <MenuItem onClick={this.handleClose}>멘토링 신청 내역</MenuItem>
+                                                    </Link> : null
+                                            }
                                         </Menu>
                                     </div>
                                 )}

--- a/src/router/MentiRouter.js
+++ b/src/router/MentiRouter.js
@@ -9,6 +9,7 @@ import {ProfileEditPage} from "../page/profile_edit_page";
 import {NoticePage} from "../page/notice_page";
 import {IntroViewPage} from "../page/intro_view_page";
 import {NoticeEditPage} from "../page/notice_edit_page";
+import MentoringCareerViewPage from "../page/mentoring_career_view_page/MentoringCareerViewPage";
 
 const MentiRouter = (props) => {
     return (
@@ -27,6 +28,8 @@ const MentiRouter = (props) => {
                 <Route exact path="/account/sign/edit" component={SignUpdatePage} />
                 <Route exact path="/account/timetable/edit" component={TimetableEditPage} />
                 <Route exact path="/account/profile/edit" component={ProfileEditPage} />
+                <Route exact path="/application/confirm" component={MentoringCareerViewPage} />
+                <Route exact path="/application/confirm/_refresh" render={() => <Redirect to="/application/confirm" />} />
             </ScrollToTop>
         </div>
     );

--- a/src/router/MentoRouter.js
+++ b/src/router/MentoRouter.js
@@ -9,6 +9,7 @@ import {ProfileEditPage} from "../page/profile_edit_page";
 import {NoticePage} from "../page/notice_page";
 import {IntroViewPage} from "../page/intro_view_page";
 import {NoticeEditPage} from "../page/notice_edit_page";
+import MentoringCareerViewPage from "../page/mentoring_career_view_page/MentoringCareerViewPage";
 
 const MentoRouter = (props) => {
     return(
@@ -27,6 +28,8 @@ const MentoRouter = (props) => {
                 <Route exact path="/account/sign/edit" component={SignUpdatePage} />
                 <Route exact path="/account/timetable/edit" component={TimetableEditPage} />
                 <Route exact path="/account/profile/edit" component={ProfileEditPage} />
+                <Route exact path="/application/confirm" component={MentoringCareerViewPage} />
+                <Route exact path="/application/confirm/_refresh" render={() => <Redirect to="/application/confirm" />} />
             </ScrollToTop>
         </div>
     );

--- a/src/router/UserRouter.js
+++ b/src/router/UserRouter.js
@@ -12,6 +12,7 @@ import {MentoApplicationPage} from "../page/mento_application_page";
 import {MentoringPage} from "../page/mentoring_page";
 import {NoticeEditPage} from "../page/notice_edit_page";
 import MentiApplicationPage from "../page/menti_application_page/MentiApplicationPage";
+import MentoringCareerViewPage from "../page/mentoring_career_view_page/MentoringCareerViewPage";
 const UserRouter = () => (
     <div>
         <ScrollToTop>
@@ -32,6 +33,8 @@ const UserRouter = () => (
             <Route exact path="/application/menti" component={MentiApplicationPage} />
             <Route exact path="/application/menti/_refresh" render={() => <Redirect to="/application/menti" />} />
             <Route exact path="/application/mento_list" component={MentoringPage} />
+            <Route exact path="/application/confirm" component={MentoringCareerViewPage} />
+            <Route exact path="/application/confirm/_refresh" render={() => <Redirect to="/application/confirm" />} />
         </ScrollToTop>
     </div>
 );


### PR DESCRIPTION
멘토링 경력 조회 기능과 이번 학기 멘토 수정과 삭제 기능 최종 구현 완료.
참고로 메뉴 구성을 수정하였음.
멘토링 경력 조회은 우측 상단의 프로필 메뉴에서 접속하도록 설계하였음.
그리고 멘토링 목록은 좌측 SM 사업이란 메뉴에 넣었음.
대신 URL 은 바뀌지 않았으니 꼭 PULL 을 진행하고 프로젝트하길 바랍니다.